### PR TITLE
Use openerTabId to maintain tree position

### DIFF
--- a/containerize.js
+++ b/containerize.js
@@ -100,7 +100,8 @@ function listener(details) {
           const createTabParams = {
             cookieStoreId: container.cookieStoreId,
             url: url,
-            pinned: false
+            pinned: false,
+            openerTabId: details.tabId
           };
 
           browser.tabs.create(createTabParams);


### PR DESCRIPTION
I noticed while using this extension that when the new containerized tab is created and the old one removed, that the position in the tab tree (I'm using sideberry extension, but probably affects other tree style tab exts) gets confused.

See images below - when the new tab is opened by clicking 'management console' under an account, the parent somehow absorbs the next sibling tab as a child.

Before opening tab:

<img width="244" alt="Screenshot 2023-02-14 at 17 07 19" src="https://user-images.githubusercontent.com/7375123/218808069-a42bd235-dea9-4eb4-8836-c3cfaadfd369.png">

After opening tab: 
<img width="244" alt="Screenshot 2023-02-14 at 17 07 40" src="https://user-images.githubusercontent.com/7375123/218808119-81c9f5c8-a8b8-47e0-b92f-5b217f1908e1.png">

This change appears to fix the issue