### PR TITLE
Fix name param

### DIFF
--- a/containerize.js
+++ b/containerize.js
@@ -68,14 +68,14 @@ function listener(details) {
 
   let filter = browser.webRequest.filterResponseData(details.requestId);
 
-  let queryString = new URLSearchParams(details.url.split("?")[1]);
+  const queryString = new URL(details.url).searchParams;
   // Parse some params for container name
   let accountRole = queryString.get("role_name");
   let accountNumber = queryString.get("account_id");
 
   // pull subdomain for folks that might have multiple SSO
   // portals that have access to the same account and role names
-  let host = /:\/\/([^\/]+)/.exec(details.originUrl)[1];
+  const host = new URL(details.originUrl).host;
   let subdomain = host.split(".")[0];
 
   let params = {

--- a/containerize.js
+++ b/containerize.js
@@ -123,19 +123,19 @@ function listener(details) {
 
         const container = await prepareContainer({ name });
 
-        const createTabParams = {
-          cookieStoreId: container.cookieStoreId,
-          url: url,
-          pinned: false
-        };
-
         // get index of tab we're about to remove, put ours at that spot
         const tab = await browser.tabs.get(details.tabId);
 
-        createTabParams.index = tab.index;
-        browser.tabs.create(createTabParams);
+        const createTabParams = {
+          cookieStoreId: container.cookieStoreId,
+          url: url,
+          pinned: false,
+          index: tab.index,
+        };
 
-        browser.tabs.remove(details.tabId);
+        await browser.tabs.create(createTabParams);
+
+        await browser.tabs.remove(details.tabId);
       } else {
         filter.write(encoder.encode(str));
       }
@@ -281,9 +281,9 @@ async function samlListener(details) {
     index: tab.index,
   };
 
-  browser.tabs.create(createTabParams);
+  await browser.tabs.create(createTabParams);
 
-  browser.tabs.remove(details.tabId);
+  await browser.tabs.remove(details.tabId);
 
   return { cancel: true };
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "AWS SSO Containers",
-  "version": "1.7",
+  "version": "1.8",
   "description": "Automatically places AWS SSO calls into containers.",
   "browser_specific_settings": {
     "gecko": {


### PR DESCRIPTION
Fixes #17.

The crux of the issue was the url parsing, which is corrected by using built-in utilities. I also added await to the browser tab operations because they [return promises](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/Tabs/create).