### PR TITLE
Container name length limit option

### DIFF
--- a/containerize.js
+++ b/containerize.js
@@ -28,6 +28,7 @@ const availableContainerColors = [
 ]
 
 let containerNameTemplate = "name role";
+let containerNameLength = 0;
 
 let accountMap = {};
 
@@ -95,6 +96,10 @@ function listener(details) {
   for (const [key, value] of Object.entries(params)) {
     name = name.replace(key, value);
   }
+  if (containerNameLength && name.length > containerNameLength) {
+    name = name.substring(0, containerNameLength - 2) + "...";
+  }
+
   let originDestination = originParams.get("destination");
   let str = '';
   let decoder = new TextDecoder("utf-8");
@@ -187,7 +192,7 @@ function accountNameListener(details) {
     }
     filter.close();
   }
-  
+
   return {};
 
 }
@@ -302,13 +307,14 @@ async function samlListener(details) {
 // Fetch our custom defined container name template
 function onGot(item) {
   containerNameTemplate = item.template || "name role";
+  containerNameLength = item.length || 0;
 }
 
 function onError(error) {
   console.log("No custom template for AWS SSO containers, using default");
 }
 
-let getting = browser.storage.sync.get("template");
+let getting = browser.storage.sync.get(["template", "length"]);
 getting.then(onGot, onError);
 
 browser.webRequest.onBeforeRequest.addListener(

--- a/containerize.js
+++ b/containerize.js
@@ -57,41 +57,7 @@ async function prepareContainer({ name, color, icon }) {
   }
 }
 
-function listener(details) {
-
-  // Temporarily commenting out as users seem to not like this
-  // https://github.com/pyro2927/AWS_SSO_Containers/issues/6
-  /*
-  if (details.cookieStoreId != "firefox-default") {
-    return {};
-  }*/
-
-  // Intercept our response
-
-  let filter = browser.webRequest.filterResponseData(details.requestId);
-
-  const queryString = new URL(details.url).searchParams;
-  const originParams = new URLSearchParams(details.originUrl.split('?').slice(1).join('?'));
-
-  // Parse some params for container name
-  let accountRole = queryString.get("role_name");
-  let accountNumber = queryString.get("account_id");
-
-  // pull subdomain for folks that might have multiple SSO
-  // portals that have access to the same account and role names
-  const host = new URL(details.originUrl).host;
-  let subdomain = host.split(".")[0];
-
-  let params = {
-    'number': accountNumber,
-    'role': accountRole,
-    'subdomain': subdomain
-  };
-  if(accountMap[accountNumber] !== undefined){
-    params["name"] = accountMap[accountNumber]["name"];
-    params["email"] = accountMap[accountNumber]["email"];
-  }
-
+function containerNameFromParams(params) {
   let name = containerNameTemplate;
 
   for (const [key, value] of Object.entries(params)) {
@@ -103,65 +69,109 @@ function listener(details) {
   if (containerNameLength && name.length > containerNameLength) {
     name = name.substring(0, containerNameLength - 2) + "...";
   }
+  return name;
+}
 
-  let originDestination = originParams.get("destination");
-  let str = '';
-  let decoder = new TextDecoder("utf-8");
-  let encoder = new TextEncoder();
+function listener(details) {
+  async function process(result) {
+    onGot(result);
 
-  filter.ondata = event => {
-    str += decoder.decode(event.data, { stream: true });
-  };
+    // Temporarily commenting out as users seem to not like this
+    // https://github.com/pyro2927/AWS_SSO_Containers/issues/6
+    /*
+    if (details.cookieStoreId != "firefox-default") {
+      return {};
+    }*/
 
-  filter.onstop = async event => {
+    // Intercept our response
 
-    // The first OPTIONS request has no response body
-    if (str.length > 0) {
-      // signInToken
-      // signInFederationLocation
-      // destination
-      const object = JSON.parse(str);
+    let filter = browser.webRequest.filterResponseData(details.requestId);
 
-      // If we have a sign-in token, hijack this into a container
-      if (object.signInToken) {
-        let destination = object.destination;
-        if (!originDestination) {
-          if (!object.destination) {
-            if (object.signInFederationLocation.includes("amazonaws-us-gov.com")) {
-              destination = "https://console.amazonaws-us-gov.com";
-            } else {
-              destination = "https://console.aws.amazon.com";
+    const queryString = new URL(details.url).searchParams;
+    const originParams = new URLSearchParams(details.originUrl.split('?').slice(1).join('?'));
+
+    // Parse some params for container name
+    let accountRole = queryString.get("role_name");
+    let accountNumber = queryString.get("account_id");
+
+    // pull subdomain for folks that might have multiple SSO
+    // portals that have access to the same account and role names
+    const host = new URL(details.originUrl).host;
+    let subdomain = host.split(".")[0];
+
+    let params = {
+      'number': accountNumber,
+      'role': accountRole,
+      'subdomain': subdomain
+    };
+    if(accountMap[accountNumber] !== undefined){
+      params["name"] = accountMap[accountNumber]["name"];
+      params["email"] = accountMap[accountNumber]["email"];
+    }
+
+    let name = containerNameFromParams(params);
+    let originDestination = originParams.get("destination");
+    let str = '';
+    let decoder = new TextDecoder("utf-8");
+    let encoder = new TextEncoder();
+
+    filter.ondata = event => {
+      str += decoder.decode(event.data, { stream: true });
+    };
+
+    filter.onstop = async event => {
+
+      // The first OPTIONS request has no response body
+      if (str.length > 0) {
+        // signInToken
+        // signInFederationLocation
+        // destination
+        const object = JSON.parse(str);
+
+        // If we have a sign-in token, hijack this into a container
+        if (object.signInToken) {
+          let destination = object.destination;
+          if (!originDestination) {
+            if (!object.destination) {
+              if (object.signInFederationLocation.includes("amazonaws-us-gov.com")) {
+                destination = "https://console.amazonaws-us-gov.com";
+              } else {
+                destination = "https://console.aws.amazon.com";
+              }
             }
           }
+          else {
+            destination = originDestination;
+          }
+
+          // Generate our federation URI and open it in a container
+          const url = object.signInFederationLocation + "?Action=login&SigninToken=" + object.signInToken + "&Issuer=" + encodeURIComponent(details.originUrl) + "&Destination=" + encodeURIComponent(destination);
+
+          const container = await prepareContainer({ name });
+
+          // get index of tab we're about to remove, put ours at that spot
+          const tab = await browser.tabs.get(details.tabId);
+
+          const createTabParams = {
+            cookieStoreId: container.cookieStoreId,
+            url: url,
+            pinned: false,
+            index: tab.index,
+          };
+
+          await browser.tabs.create(createTabParams);
+
+          await browser.tabs.remove(details.tabId);
+        } else {
+          filter.write(encoder.encode(str));
         }
-        else {
-          destination = originDestination;
-        }
-
-        // Generate our federation URI and open it in a container
-        const url = object.signInFederationLocation + "?Action=login&SigninToken=" + object.signInToken + "&Issuer=" + encodeURIComponent(details.originUrl) + "&Destination=" + encodeURIComponent(destination);
-
-        const container = await prepareContainer({ name });
-
-        // get index of tab we're about to remove, put ours at that spot
-        const tab = await browser.tabs.get(details.tabId);
-
-        const createTabParams = {
-          cookieStoreId: container.cookieStoreId,
-          url: url,
-          pinned: false,
-          index: tab.index,
-        };
-
-        await browser.tabs.create(createTabParams);
-
-        await browser.tabs.remove(details.tabId);
-      } else {
-        filter.write(encoder.encode(str));
       }
-    }
-    filter.close();
-  };
+      filter.close();
+    };
+  }
+
+  let getting = browser.storage.sync.get(["template", "length", "slug"]);
+  getting.then(process);
 
   return {};
 }
@@ -202,108 +212,111 @@ function accountNameListener(details) {
 }
 
 async function samlListener(details) {
-  if (details.statusCode != 302) {
-    return {};
-  }
+  async function process(result) {
+    onGot(result);
 
-  const setCookie = details.responseHeaders.find(header => header.name == "set-cookie");
-  const redirectUrl = details.responseHeaders.find(header => header.name == "location").value;
+    if (details.statusCode != 302) {
+      return {};
+    }
 
-  const cookies = setCookie.value.split('\n').map(fullCookie => fullCookie.split("; ").map(cookiePart => cookiePart.split('=')));
+    const setCookie = details.responseHeaders.find(header => header.name == "set-cookie");
+    const redirectUrl = details.responseHeaders.find(header => header.name == "location").value;
 
-  const encodedUserInfo = cookies.find(cookie => cookie[0][0] == "aws-userInfo")[0][1];
-  const userInfo = JSON.parse(decodeURIComponent(encodedUserInfo));
-  const roleArn = userInfo.arn;
-  const splitArn = roleArn.split(':');
-  const splitRole = splitArn[5].split('/');
+    const cookies = setCookie.value.split('\n').map(fullCookie => fullCookie.split("; ").map(cookiePart => cookiePart.split('=')));
 
-  const name = userInfo.alias;
-  const number = splitArn[4];
-  const role = splitRole[1];
-  const email = splitRole[2];
-  const subdomain = 'saml';
+    const encodedUserInfo = cookies.find(cookie => cookie[0][0] == "aws-userInfo")[0][1];
+    const userInfo = JSON.parse(decodeURIComponent(encodedUserInfo));
+    const roleArn = userInfo.arn;
+    const splitArn = roleArn.split(':');
+    const splitRole = splitArn[5].split('/');
 
-  let params = { name, number, role, email, subdomain };
+    const name = userInfo.alias;
+    const number = splitArn[4];
+    const role = splitRole[1];
+    const email = splitRole[2];
+    const subdomain = 'saml';
 
-  let containerName = containerNameTemplate;
+    let params = {name, number, role, email, subdomain};
 
-  for (const [key, value] of Object.entries(params)) {
-    containerName = containerName.replace(key, value);
-  }
+    let containerName = containerNameFromParams(params);
 
-  const container = await prepareContainer({ name: containerName });
+    const container = await prepareContainer({name: containerName});
 
-  const cookieAttributeMapping = {
-    Path: 'path',
-    SameSite: 'sameSite',
-    Secure: 'secure',
-    Domain: 'domain',
-    Expires: 'expirationDate',
-    HttpOnly: 'httpOnly',
-  }
+    const cookieAttributeMapping = {
+      Path: 'path',
+      SameSite: 'sameSite',
+      Secure: 'secure',
+      Domain: 'domain',
+      Expires: 'expirationDate',
+      HttpOnly: 'httpOnly',
+    }
 
-  const sameSiteMapping = {
-    None: 'no_restriction',
-    Lax: 'lax',
-    Strict: 'strict',
-  }
+    const sameSiteMapping = {
+      None: 'no_restriction',
+      Lax: 'lax',
+      Strict: 'strict',
+    }
 
-  for (const cookie of cookies) {
-    for (const cookieAttribute of cookie.slice(1)) {
-      if (cookieAttribute[0] == 'SameSite') {
-        cookieAttribute[1] = sameSiteMapping[cookieAttribute[1]];
-      }
+    for (const cookie of cookies) {
+      for (const cookieAttribute of cookie.slice(1)) {
+        if (cookieAttribute[0] == 'SameSite') {
+          cookieAttribute[1] = sameSiteMapping[cookieAttribute[1]];
+        }
 
-      if (cookieAttribute[0] == 'Max-Age') {
-        cookieAttribute[0] = 'expirationDate';
-        cookieAttribute[1] = Date.now() + parseInt(cookieAttribute[1]);
-      }
+        if (cookieAttribute[0] == 'Max-Age') {
+          cookieAttribute[0] = 'expirationDate';
+          cookieAttribute[1] = Date.now() + parseInt(cookieAttribute[1]);
+        }
 
-      if (cookieAttribute[0] == 'Expires') {
-        cookieAttribute[0] = 'expirationDate';
-        cookieAttribute[1] = Date.parse(cookieAttribute[1]);
-      }
+        if (cookieAttribute[0] == 'Expires') {
+          cookieAttribute[0] = 'expirationDate';
+          cookieAttribute[1] = Date.parse(cookieAttribute[1]);
+        }
 
-      if (cookieAttribute.length == 1) {
-        cookieAttribute.push(true);
-      }
+        if (cookieAttribute.length == 1) {
+          cookieAttribute.push(true);
+        }
 
-      if (cookieAttributeMapping[cookieAttribute[0]]) {
-        cookieAttribute[0] = cookieAttributeMapping[cookieAttribute[0]];
+        if (cookieAttributeMapping[cookieAttribute[0]]) {
+          cookieAttribute[0] = cookieAttributeMapping[cookieAttribute[0]];
+        }
       }
     }
-  }
 
-  const cookiesToSet = cookies.map(cookie => {
-    const [name, value] = cookie[0];
+    const cookiesToSet = cookies.map(cookie => {
+      const [name, value] = cookie[0];
 
-    return {
-      ...Object.fromEntries(cookie.slice(1)),
-      name,
-      value,
-    };
-  });
-
-  for (const cookie of cookiesToSet) {
-    browser.cookies.set({
-      ...cookie,
-      url: details.url,
-      storeId: container.cookieStoreId,
+      return {
+        ...Object.fromEntries(cookie.slice(1)),
+        name,
+        value,
+      };
     });
+
+    for (const cookie of cookiesToSet) {
+      browser.cookies.set({
+        ...cookie,
+        url: details.url,
+        storeId: container.cookieStoreId,
+      });
+    }
+
+    const tab = await browser.tabs.get(details.tabId);
+
+    const createTabParams = {
+      cookieStoreId: container.cookieStoreId,
+      url: redirectUrl,
+      pinned: false,
+      index: tab.index,
+    };
+
+    await browser.tabs.create(createTabParams);
+
+    await browser.tabs.remove(details.tabId);
   }
 
-  const tab = await browser.tabs.get(details.tabId);
-
-  const createTabParams = {
-    cookieStoreId: container.cookieStoreId,
-    url: redirectUrl,
-    pinned: false,
-    index: tab.index,
-  };
-
-  await browser.tabs.create(createTabParams);
-
-  await browser.tabs.remove(details.tabId);
+  let getting = browser.storage.sync.get(["template", "length", "slug"]);
+  getting.then(process);
 
   return { cancel: true };
 }
@@ -311,7 +324,7 @@ async function samlListener(details) {
 // Fetch our custom defined container name template
 function onGot(item) {
   containerNameTemplate = item.template || "name role";
-  containerNameLength = item.length || 0;
+  containerNameLength = parseInt(item.length, 10) || 0;
   containerNameSlug = item.slug || "";
 }
 

--- a/containerize.js
+++ b/containerize.js
@@ -29,6 +29,7 @@ const availableContainerColors = [
 
 let containerNameTemplate = "name role";
 let containerNameLength = 0;
+let containerNameSlug = "";
 
 let accountMap = {};
 
@@ -95,6 +96,9 @@ function listener(details) {
 
   for (const [key, value] of Object.entries(params)) {
     name = name.replace(key, value);
+  }
+  if (containerNameSlug) {
+    name = name.replaceAll(containerNameSlug, "");
   }
   if (containerNameLength && name.length > containerNameLength) {
     name = name.substring(0, containerNameLength - 2) + "...";
@@ -308,13 +312,14 @@ async function samlListener(details) {
 function onGot(item) {
   containerNameTemplate = item.template || "name role";
   containerNameLength = item.length || 0;
+  containerNameSlug = item.slug || "";
 }
 
 function onError(error) {
   console.log("No custom template for AWS SSO containers, using default");
 }
 
-let getting = browser.storage.sync.get(["template", "length"]);
+let getting = browser.storage.sync.get(["template", "length", "slug"]);
 getting.then(onGot, onError);
 
 browser.webRequest.onBeforeRequest.addListener(

--- a/options.html
+++ b/options.html
@@ -2,14 +2,30 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <style>
+      form div {
+        display:grid;
+        grid-template-columns: max-content max-content;
+        grid-gap:5px;
+      }
+      form div label {
+        text-align:right;
+      }
+    </style>
   </head>
 
   <body>
     <form>
-      <label>Container name template: <input type="text" id="template" name="template" /></label>
-      <br/>
-      <label>Preview: <input type="text" id="preview" readonly /></label>
-      <br/>
+      <div>
+        <label for="template">Container name template:</label>
+        <input type="text" id="template" name="template" size="40" />
+
+        <label for="preview">Preview:</label>
+        <input type="text" id="preview" size="40" readonly />
+
+        <label for="length">Maximum container name length:</label>
+        <input type="number" id="length" name="length" />
+      </div>
       <p>Available variables:</p>
       <ul>
         <li>name</li>
@@ -18,7 +34,6 @@
         <li>role</li>
         <li>subdomain</li>
       </ul>
-      <br/>
       <button type="submit">Save</button>
     </form>
 

--- a/options.html
+++ b/options.html
@@ -21,10 +21,13 @@
         <input type="text" id="template" name="template" size="40" />
 
         <label for="preview">Preview:</label>
-        <input type="text" id="preview" size="40" readonly />
+        <input type="text" id="preview" readonly />
 
         <label for="length">Maximum container name length:</label>
         <input type="number" id="length" name="length" />
+
+        <label for="slug">Common name prefix to remove:</label>
+        <input type="text" id="slug" name="slug" />
       </div>
       <p>Available variables:</p>
       <ul>

--- a/options.js
+++ b/options.js
@@ -22,7 +22,7 @@ function populatePreview(text, length, slug) {
   if (slug) {
     text = text.replaceAll(slug, "");
   }
-  if (length && text.length > length) {
+  if (length && text.length > length && length > 0) {
     text = text.substring(0, length - 2) + "...";
   }
   document.querySelector("#preview").value = text;

--- a/options.js
+++ b/options.js
@@ -10,13 +10,17 @@ function saveOptions(e) {
   e.preventDefault();
   browser.storage.sync.set({
     template: document.querySelector("#template").value,
-    length: document.querySelector("#length").value || 0
+    length: document.querySelector("#length").value || 0,
+    slug: document.querySelector("#slug").value
   });
 }
 
-function populatePreview(text, length) {
+function populatePreview(text, length, slug) {
   for (const [key, value] of Object.entries(examples)) {
     text = text.replace(key, value);
+  }
+  if (slug) {
+    text = text.replaceAll(slug, "");
   }
   if (length && text.length > length) {
     text = text.substring(0, length - 2) + "...";
@@ -28,24 +32,35 @@ function restoreOptions() {
   function setCurrentChoice(result) {
     let text = result.template || "name role";
     let length = parseInt(result.length, 10);
+    let slug = result.slug || "";
     document.querySelector("#template").value = text;
     document.querySelector("#length").value = length || 0;
-    populatePreview(text, length);
+    document.querySelector("#slug").value = slug;
+    populatePreview(text, length, slug);
   }
 
   function onError(error) {
     console.log(`Error: ${error}`);
   }
 
-  let getting = browser.storage.sync.get(["template", "length"]);
+  let getting = browser.storage.sync.get(["template", "length", "slug"]);
   getting.then(setCurrentChoice, onError);
 }
 
 document.addEventListener("DOMContentLoaded", restoreOptions);
 document.querySelector("form").addEventListener("submit", saveOptions);
 document.querySelector("#template").addEventListener("input", function(evt) {
-  populatePreview(this.value, document.querySelector("#length").value);
+  let length = document.querySelector("#length").value;
+  let slug = document.querySelector("#slug").value || "";
+  populatePreview(this.value, length, slug);
 });
 document.querySelector("#length").addEventListener("input", function(evt) {
-  populatePreview(document.querySelector("#template").value, this.value);
+  let template = document.querySelector("#template").value;
+  let slug = document.querySelector("#slug").value || "";
+  populatePreview(template, this.value, slug);
+});
+document.querySelector("#slug").addEventListener("input", function(evt) {
+  let template = document.querySelector("#template").value;
+  let length = document.querySelector("#length").value;
+  populatePreview(template, length, this.value || "");
 });

--- a/options.js
+++ b/options.js
@@ -3,19 +3,23 @@ let examples = {
   'email': 'Prod@example.com',
   'number': '123456',
   'role': 'InfraEng',
-  'subdomain': 'MegaCorp'
+  'subdomain': 'CompuGlobalHyperMegaNet'
 };
 
 function saveOptions(e) {
   e.preventDefault();
   browser.storage.sync.set({
-    template: document.querySelector("#template").value
+    template: document.querySelector("#template").value,
+    length: document.querySelector("#length").value || 0
   });
 }
 
-function populatePreview(text) {
+function populatePreview(text, length) {
   for (const [key, value] of Object.entries(examples)) {
     text = text.replace(key, value);
+  }
+  if (length && text.length > length) {
+    text = text.substring(0, length - 2) + "...";
   }
   document.querySelector("#preview").value = text;
 }
@@ -23,20 +27,25 @@ function populatePreview(text) {
 function restoreOptions() {
   function setCurrentChoice(result) {
     let text = result.template || "name role";
+    let length = parseInt(result.length, 10);
     document.querySelector("#template").value = text;
-    populatePreview(text);
+    document.querySelector("#length").value = length || 0;
+    populatePreview(text, length);
   }
 
   function onError(error) {
     console.log(`Error: ${error}`);
   }
 
-  let getting = browser.storage.sync.get("template");
+  let getting = browser.storage.sync.get(["template", "length"]);
   getting.then(setCurrentChoice, onError);
 }
 
 document.addEventListener("DOMContentLoaded", restoreOptions);
 document.querySelector("form").addEventListener("submit", saveOptions);
 document.querySelector("#template").addEventListener("input", function(evt) {
-  populatePreview(this.value);
+  populatePreview(this.value, document.querySelector("#length").value);
+});
+document.querySelector("#length").addEventListener("input", function(evt) {
+  populatePreview(document.querySelector("#template").value, this.value);
 });


### PR DESCRIPTION
As described in #26, this adds two minor features to work around an issue with the Container Name addon [Long Names Word wrap are overlapping with other entries #2544](https://github.com/mozilla/multi-account-containers/issues/2544):

![container-name-wrapping-fixed](https://github.com/pyro2927/AWS_SSO_Containers/assets/3992307/5ed41450-2079-4b30-b4a0-37dad80884d6)

1. Limit the length of a container name to a configurable max length. An option seemed like the way to go here, because the exact number of characters might change depending on the OS, browser theme, accessibility settings, etc.
2. Option to delete a common string like "MyCompany" from all container names. This helps if the unique part is at the end of the name

I used the name "slug" for that second option because it reminded me of [slugs in URLs](https://stackoverflow.com/questions/4230846/what-is-the-etymology-of-slug-in-a-url), but in this case it's deleting the *least* unique part of the name. Oh well, couldn't think of a better word for it.