### PR TITLE
fix: Make SAML HTTP header logic case-insensitive.

### DIFF
--- a/containerize.js
+++ b/containerize.js
@@ -220,8 +220,8 @@ async function samlListener(details) {
   async function process(result) {
     onGot(result);
 
-    const setCookie = details.responseHeaders.find(header => header.name == "set-cookie");
-    const redirectUrl = details.responseHeaders.find(header => header.name == "location").value;
+    const setCookie = details.responseHeaders.find(header => header.name.toLowerCase() == "set-cookie");
+    const redirectUrl = details.responseHeaders.find(header => header.name.toLowerCase() == "location").value;
 
     const cookies = setCookie.value.split('\n').map(fullCookie => fullCookie.split("; ").map(cookiePart => cookiePart.split('=')));
 


### PR DESCRIPTION
Closes #31 

Updated the function passed to find() when searching for http headers to include a call to toLowerCase() before making a comparison. 

Previously, when logging in with a SAML flow, if headers returned in the response were of mixed case then the logic would fail with an uncaught TypeError: details.responseHeaders.find(...) is undefined.