### PR TITLE
fix: support new IAM Identity Center portal URLs (portal.amazonaws.com / portal.app.aws)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "AWS SSO Containers",
-  "version": "1.15",
+  "version": "1.16",
   "license": "SEE LICENSE",
   "description": "Automatically places AWS SSO calls into containers.",
   "browser_specific_settings": {

--- a/manifest.json
+++ b/manifest.json
@@ -20,6 +20,8 @@
     "webRequestBlocking",
     "https://signin.aws.amazon.com/saml",
     "https://*.awsapps.com/start/*",
+    "https://*.portal.amazonaws.com/*",
+    "https://*.portal.app.aws/*",
     "https://*.amazonaws.com/federation/console?*",
     "https://*.amazonaws-us-gov.com/federation/console?*",
     "https://*.amazonaws.cn/federation/console?*",


### PR DESCRIPTION
AWS introduced new access portal endpoints for IAM Identity Center — default for instances created from February 2026, and already reachable today as alternative / multi-region endpoints:

- `https://<idc-instance-id>.<region>.portal.amazonaws.com` (alternative IPv4)
- `https://<idc-instance-id>.portal.<region>.app.aws` (dual-stack)

When the portal loads from one of these hosts, the extension lacks host permissions for the originating page, so `webRequest.filterResponseData` silently skips reading the cross-origin `federation/console` XHR and no container is opened.

Adds the two missing host patterns to `manifest.json`. The federation token endpoint itself (`*.amazonaws.com/federation/console`) is unchanged, so no `containerize.js` changes are needed.

Version bumped 1.15 → 1.16.

Ref: https://docs.aws.amazon.com/singlesignon/latest/userguide/multi-region-workforce-access.html